### PR TITLE
Renderer supports JSON results

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -196,7 +196,11 @@ class Renderer
 
     protected function dispatchScript(): string
     {
-        return "var dispatch = {$this->engine->getDispatchHandler()}";
+        return <<<JS
+var dispatch = function (result) {
+    return {$this->engine->getDispatchHandler()}(JSON.stringify(result))
+}
+JS;
     }
 
     protected function applicationScript(): string

--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -146,7 +146,7 @@ class Renderer
         return $this;
     }
 
-    public function render(): string
+    public function render()
     {
         if (! $this->enabled) {
             return $this->fallback;
@@ -168,6 +168,14 @@ class Renderer
             return $this->fallback;
         }
 
+        $decoded = json_decode($result, true);
+
+        if (json_last_error() === JSON_ERROR_NONE) {
+            // Looks like the engine returned a JSON object.
+            return $decoded;
+        }
+
+        // Looks like the engine returned a string.
         return $result;
     }
 

--- a/tests/Renderer/RendererTest.php
+++ b/tests/Renderer/RendererTest.php
@@ -21,6 +21,19 @@ class RendererTest extends TestCase
     }
 
     /** @test */
+    public function it_can_decode_json()
+    {
+        $result = $this->renderer
+            ->entry(__DIR__.'/../scripts/app-with-json-server.js')
+            ->render();
+
+        $this->assertEquals(
+            ['foo' => 'bar'],
+            $result
+        );
+    }
+
+    /** @test */
     public function it_renders_a_fallback_when_disabled()
     {
         $result = $this->renderer

--- a/tests/scripts/app-with-json-server.js
+++ b/tests/scripts/app-with-json-server.js
@@ -1,1 +1,1 @@
-dispatch(JSON.stringify({ foo: 'bar' }));
+dispatch({ foo: 'bar' });

--- a/tests/scripts/app-with-json-server.js
+++ b/tests/scripts/app-with-json-server.js
@@ -1,0 +1,1 @@
+dispatch(JSON.stringify({ foo: 'bar' }));


### PR DESCRIPTION
I've added the functionality to return JSON objects from the JS script. This way the renderer becomes quite flexible and should allow you to return additional context like rendered CSS for example.