### PR TITLE
Check for existence of 'this' in Renderer::environmentScript()

### DIFF
--- a/src/Renderer.php
+++ b/src/Renderer.php
@@ -188,7 +188,7 @@ class Renderer
         }, $this->env, array_keys($this->env));
 
         return implode(';', [
-            '(function () { if (this.process != null) { return; } this.process = { env: {}, argv: [] }; }).call(null)',
+            '(function () { if (!this || this.process != null) { return; } this.process = { env: {}, argv: [] }; }).call(null)',
             implode(';', $envAssignments),
             "var context = {$context}",
         ]);


### PR DESCRIPTION
This will help prevent errors when using Vite instead of Webpack.

Fix for issue #62 